### PR TITLE
build: fix pre-existing Windows/UWP CI build failures (MSVC C4875 + JSI include path)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,9 +61,12 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # A newer MSVC (windows-latest) emits C4875 ("a non-string literal argument to [[gsl::suppress]] is
 # deprecated") from the vendored GSL headers, which several targets compile with warnings-as-error.
 # Suppress this dependency-side deprecation so the Windows build isn't broken by toolchain drift. Must
-# be set before arcana.cpp / Core / Polyfills are added below so they inherit it.
+# be set before arcana.cpp / Core / Polyfills are added below so they inherit it. Scoped to C++ (the
+# warning only fires for GSL's C++ [[gsl::suppress]] attribute); kept directory-wide because GSL is
+# pulled in transitively by many targets (arcana, AppRuntime, the polyfills) and no first-party code
+# uses a non-string [[gsl::suppress]], so this doesn't mask our own warnings.
 if(MSVC)
-    add_compile_options(/wd4875)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/wd4875>)
 endif()
 
 # --------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,14 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# A newer MSVC (windows-latest) emits C4875 ("a non-string literal argument to [[gsl::suppress]] is
+# deprecated") from the vendored GSL headers, which several targets compile with warnings-as-error.
+# Suppress this dependency-side deprecation so the Windows build isn't broken by toolchain drift. Must
+# be set before arcana.cpp / Core / Polyfills are added below so they inherit it.
+if(MSVC)
+    add_compile_options(/wd4875)
+endif()
+
 # --------------------------------------------------
 # Options
 # --------------------------------------------------

--- a/Core/Node-API-JSI/CMakeLists.txt
+++ b/Core/Node-API-JSI/CMakeLists.txt
@@ -57,7 +57,12 @@ if(NOT TARGET jsi)
 endif()
 
 target_include_directories(napi
-    PUBLIC "include")
+    PUBLIC "include"
+    # napi.h pulls in the shared <napi/js_native_api_types.h>, which lives in
+    # Core/Node-API/Include/Shared. That sibling isn't built when the engine is JSI
+    # (Core/CMakeLists.txt selects Node-API-JSI instead of Node-API), so reference the shared
+    # headers directly here -- otherwise the JSI napi fails to compile with C1083.
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../Node-API/Include/Shared")
 
 target_link_libraries(napi
     PUBLIC jsi)

--- a/Core/Node-API-JSI/CMakeLists.txt
+++ b/Core/Node-API-JSI/CMakeLists.txt
@@ -57,12 +57,13 @@ if(NOT TARGET jsi)
 endif()
 
 target_include_directories(napi
-    PUBLIC "include"
-    # napi.h pulls in the shared <napi/js_native_api_types.h>, which lives in
-    # Core/Node-API/Include/Shared. That sibling isn't built when the engine is JSI
-    # (Core/CMakeLists.txt selects Node-API-JSI instead of Node-API), so reference the shared
-    # headers directly here -- otherwise the JSI napi fails to compile with C1083.
-    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../Node-API/Include/Shared")
+    PUBLIC
+        "include"
+        # napi.h pulls in the shared <napi/js_native_api_types.h>, which lives in
+        # Core/Node-API/Include/Shared. That sibling isn't built when the engine is JSI
+        # (Core/CMakeLists.txt selects Node-API-JSI instead of Node-API), so reference the shared
+        # headers directly here -- otherwise the JSI napi fails to compile with C1083.
+        "${CMAKE_CURRENT_SOURCE_DIR}/../Node-API/Include/Shared")
 
 target_link_libraries(napi
     PUBLIC jsi)


### PR DESCRIPTION
Two independent, pre-existing build-config fixes that unbreak the fork's Windows/UWP CI on `main`. No
feature changes; surfaced while standing up broad fork CI for the N-API stack but fully independent of
it.

1. **MSVC `C4875` from vendored GSL** (`CMakeLists.txt`) — windows-latest's newer MSVC promotes the
   deprecated `[[gsl::suppress]]` non-string-literal warning (from vendored GSL headers) to an error
   under `/WX`, breaking **every** Win32/UWP build (arcana + AppRuntime + polyfills all pull in GSL).
   Suppress the dependency-side deprecation.

2. **JSI shared-header include path** (`Core/Node-API-JSI/CMakeLists.txt`) — the JSI `napi` target only
   had its own `include/` on the path, but `napi.h` includes the shared `<napi/js_native_api_types.h>`
   from `Core/Node-API/Include/Shared` (not built when the engine is JSI), so the JSI build failed with
   `C1083`. Add the shared directory.

Together these take the fork's Win32/UWP × {Chakra, V8, JSI} jobs from red to green; everything else was
already green on `main`.